### PR TITLE
Updated to use PIL over subprocess/ffprobe

### DIFF
--- a/mkpblock.py
+++ b/mkpblock.py
@@ -2,97 +2,17 @@
 
 # convert image to METADATA_BLOCK_PICTURE
 
-import os
-import re
 import sys
 import struct
 import base64
-import subprocess
+from pathlib import Path
+from PIL import Image, UnidentifiedImageError
+import io
 
-def ffprobe(path):
-    proc = subprocess.Popen([
-            "ffprobe",
-            "-loglevel", "quiet",
-            "-count_packets",
-            "-count_frames",
-            "-show_entries", "format:stream",
-        path],
-        stdin=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        stdout=subprocess.PIPE)
-
-    out = str(proc.communicate()[0], 'utf-8')
-
-    proc.wait()
-
-    if proc.returncode != 0:
-        raise RuntimeError("ffprobe: nonzero exit status ({})"
-            .format(proc.returncode))
-
-    kv = {}
-
-    tag = None
-    tgt = None
-
-    for line in out.split("\n"):
-        line = line.strip()
-
-        m = re.match("^\[([^/][^\]]+)\]$", line)
-        if m:
-            tmp = m.group(1)
-
-            if tag != None:
-                continue
-
-            if tmp == "FORMAT":
-                tgt = kv
-
-            elif tmp == "STREAM":
-                tgt = {}
-
-            tag = tmp
-
-            continue
-
-        m = re.match("^\[/([^\]]+)\]$", line)
-        if m:
-            tmp = m.group(1)
-
-            if tag != tmp:
-                continue
-
-            if tmp == "STREAM":
-                if "index" in tgt:
-                    if not "__streams__" in kv:
-                        kv["__streams__"] = []
-
-                    l = kv["__streams__"]
-                    i = int(tgt["index"])
-
-                    if i > (len(l) - 1):
-                        l.extend([None for x in range(len(l), i + 1)])
-
-                    kv["__streams__"][i] = tgt
-
-            tag = None
-            tgt = None
-
-            continue
-
-        m = re.match("^([^=]+)=(.+)$", line)
-        if m:
-            key = m.group(1)
-            val = m.group(2)
-
-            if tgt != None:
-                tgt[key] = val
-
-            continue
-
-    return kv
 
 def usage():
-    print("""
+    print(
+        """
 Usage: IDV3v2_TYPE DESCRIPTION IMAGE"
 Where IDV3v2_TYPE is one of:
    0 - Other
@@ -116,83 +36,85 @@ Where IDV3v2_TYPE is one of:
   18 - Illustration
   19 - Band/artist logotype
   20 - Publisher/Studio logotype
-    """.strip(), file=sys.stderr)
+    """.strip(),
+        file=sys.stderr,
+    )
     sys.exit(1)
+
+
+def image_bit_depth(image: Image.Image) -> int:
+    """
+    Returns the bit depth of the image. Equivalent to bits_per_raw_sample from FFmpeg/FFprobe.
+    """
+    mode = image.mode
+    if mode == "1":
+        return 1
+    elif mode in {"L", "P", "RGB", "RGBA", "CMYK", "YCbCr", "LAB", "HSV"}:
+        return 8
+    elif mode in {"I", "F"}:
+        return 32
+    else:
+        raise ValueError(f"Unsupported image mode: {mode}")
+
 
 def main():
     if len(sys.argv) != 4:
         usage()
 
-    # get args
-    idv3 = sys.argv[1].strip()
-    desc = sys.argv[2].strip()
-    file = sys.argv[3]
-
-    # validate idv3 type
+    # get args and validate idv3 type
     try:
-        idv3 = int(idv3)
-    except:
+        idv3 = int(sys.argv[1].strip())
+    except ValueError:
         usage()
+    desc = sys.argv[2].strip()
+    file = Path(sys.argv[3])
+
     if (idv3 < 0) or (idv3 > 20):
         usage()
 
-    # check that file exists
-    if not (os.path.isfile(file) and os.access(file, os.R_OK)):
+    # read file to bytes and open image
+    try:
+        image_bytes = file.read_bytes()
+        img = Image.open(io.BytesIO(image_bytes))
+    except (FileNotFoundError, IsADirectoryError, PermissionError):
         print(f"Can't access '{file}'", file=sys.stderr)
         return 1
-
-    # get file mime type 
-    tmp = subprocess.check_output(["file", "--mime", file])
-    tmp = tmp.split(b":", 1)
-    tmp = tmp[1].split(b";", 1)
-    tmp = tmp[0].strip()
-    if not tmp.startswith(b"image/"):
-        print(f"'{file}' is not an image ({str(tmp, 'utf-8')})", file=sys.stderr)
+    except UnidentifiedImageError:
+        # PIL can't open the file
+        print(f"File: '{file}' is not an image supported by PIL", file=sys.stderr)
         return 1
-    mime = tmp
 
-    # get width, heigth and bpp
-    tmp = ffprobe(file)
-    tmp = tmp["__streams__"][0]
-    w   = tmp["width"]
-    h   = tmp["height"]
-    bpp = tmp["bits_per_raw_sample"]
-    if bpp == "N/A":
-        # determine manually
-        tmp = tmp["pix_fmt"]
-        if tmp == "rgb24":
-            bpp = 24
-        else:
-            print("Unable to detemine pixel depth.", file=sys.stderr)
-            return 1
-    w   = int(w)
-    h   = int(h)
-    bpp = int(bpp)
+    # get file mime type and convert to unicode bytes
+    mime = img.get_format_mimetype().encode("utf-8")
+
+    # get width, heigth
+    width, height = img.size
+
+    # get bits_per_pixel
+    try:
+        bits_per_pixel = image_bit_depth(img)
+    except ValueError:
+        print(f"Unsupported image in mode: {img.mode}", file=sys.stderr)
+        return 1
+
+    desc = desc.encode("utf-8")
 
     # construct data
     data = bytearray()
-    data += struct.pack(">I", idv3)
-    data += struct.pack(">I", len(mime))
+    data += struct.pack(">II", idv3, len(mime))
     data += mime
     data += struct.pack(">I", len(desc))
-    if len(desc) > 0:
-        data += bytes(desc, "utf-8")
-    data += struct.pack(">I", w)
-    data += struct.pack(">I", h)
-    data += struct.pack(">I", bpp)
-    data += b'\0\0\0\0'
-    with open(file, "rb") as fp:
-        tmp = fp.read()
-        data += struct.pack(">I", len(tmp))
-        data += tmp
+    if desc:
+        data += desc
+    data += struct.pack(">IIIII", width, height, bits_per_pixel, 0, len(image_bytes))
+    data += image_bytes
 
     # write output
-    sys.stdout.buffer.write(b"METADATA_BLOCK_PICTURE=")
-    sys.stdout.buffer.write(base64.b64encode(data))
-    sys.stdout.buffer.write(b"\n")
+    sys.stdout.buffer.write(b"METADATA_BLOCK_PICTURE=" + base64.b64encode(data) + b"\n")
     sys.stdout.buffer.flush()
 
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/mkpblock.py
+++ b/mkpblock.py
@@ -7,7 +7,7 @@ import struct
 import base64
 from pathlib import Path
 from PIL import Image, UnidentifiedImageError
-import io
+from io import BytesIO
 
 
 def usage():
@@ -75,7 +75,7 @@ def main():
     # read file to bytes and open image
     try:
         image_bytes = file.read_bytes()
-        img = Image.open(io.BytesIO(image_bytes))
+        img = Image.open(BytesIO(image_bytes))
     except (FileNotFoundError, IsADirectoryError, PermissionError):
         print(f"Can't access '{file}'", file=sys.stderr)
         return 1


### PR DESCRIPTION
Changes made
1) Use PIL to obtain the image file's mime-type, dimensions, and bits_per_pixel over using external ffprobe
- This is likely faster as PIL is a python library itself
- This also means that we don't have to read/load the file multiple times; previously, the file would be loaded externally by ffprobe, then read again to add its data into the final string
- This avoids needing to check that the mime-type string begins with "image/", as PIL raises UnidentifiedImageError for non-image files.

3) Removed calling os/re/subprocess libraries
- the exceptions raised when attempting to read the file are handle is_file() and access() checks
- No longer calling external subprocesses or needing to parse the output with re.match

4) Condensed calls to struct.pack for integer values Calls like:
```
data += struct.pack(">I", number1)
data += struct.pack(">I", number2)
```

Do the same thing as
```
data += struct.pack(">II", number1, number2)
```

Added libraries:
- From PIL, Image and UnidentifiedImageError classes (for loading/reading images and for the catching the exception thrown by a bad file)
- from pathlib, Path class (for its read_bytes() conveniency function)
- From io, BytesIO(), because PIL's Image class can only read a file loaded as bytes if it's wrapped inside that function.